### PR TITLE
Added `height` of `Main` container component to `100dvh` to fix bug in Safari iOS

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -23,6 +23,9 @@ function Home() {
     >   
       <Main
         background="#EAD6DF"
+        style={{
+          height: "100dvh"
+        }}
       >
         <CollapsibleNav></CollapsibleNav>
         <Headshot/>

--- a/src/client/components/About.tsx
+++ b/src/client/components/About.tsx
@@ -10,6 +10,9 @@ const About = () => {
     <Grommet theme={theme} full>   
       <Main
         background="#EAD6DF"
+        style={{
+          height: "100dvh"
+        }}
       >
         <CollapsibleNav/>
         <ResponsiveContext.Consumer>

--- a/src/client/components/Headshot.tsx
+++ b/src/client/components/Headshot.tsx
@@ -9,7 +9,7 @@ const Headshot = () => {
             height="fit-content" 
             width="fit-content"
             style={{
-                maxHeight: "40vh",
+                maxHeight: "40dvh",
                 minWidth: "300px",
                 minHeight: "300px"
             }} 

--- a/src/client/components/Projects.tsx
+++ b/src/client/components/Projects.tsx
@@ -21,7 +21,7 @@ const Projects = () => {
             <Main
                 background="#EAD6DF"
                 style={{
-                    minHeight: "100vh"
+                    height: "100dvh"
                 }}
                 overflow="auto"
             >


### PR DESCRIPTION
Bug before change (`Main` had a `minHeight` of `100vh`). Address bar at bottom was cutting off content when first scrolling:

https://github.com/user-attachments/assets/2edc560b-a359-47f7-bec6-540ea83fc714


After fix (deleted `minHeight` attribute and added `height="100dvh`):

https://github.com/user-attachments/assets/b74a3871-149e-4ca3-b5ef-c0bf2917348e

